### PR TITLE
Fix generation of content types

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"mime"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/gorilla/pat"
@@ -38,7 +39,9 @@ func (web Web) Static(pattern string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		fp := strings.TrimSuffix(pattern, "{{file}}") + req.URL.Query().Get(":file")
 		if b, err := web.asset(fp); err == nil {
-			w.Header().Set("Content-Type", mime.TypeByExtension(fp))
+			ext := filepath.Ext(fp)
+
+			w.Header().Set("Content-Type", mime.TypeByExtension(ext))
 			w.WriteHeader(200)
 			w.Write(b)
 			return

--- a/web/web.go
+++ b/web/web.go
@@ -102,6 +102,7 @@ func (web Web) Index() func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.WriteHeader(200)
 		w.Write(b.Bytes())
 	}


### PR DESCRIPTION
Currently static content is being assigned a `Content-Type` header of an empty string.

The index works out of the box correctly, but will misbehave if other middleware is added to the request handler.