### PR TITLE
Fix mailhog/MailHog#25 Provide a relative/local WebContext Path argument

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,12 +10,14 @@ func DefaultConfig() *Config {
 	return &Config{
 		APIHost:    "",
 		UIBindAddr: "0.0.0.0:8025",
+		WebPath:    "",
 	}
 }
 
 type Config struct {
 	APIHost    string
 	UIBindAddr string
+	WebPath    string
 }
 
 var cfg = DefaultConfig()
@@ -27,4 +29,5 @@ func Configure() *Config {
 func RegisterFlags() {
 	flag.StringVar(&cfg.APIHost, "api-host", envconf.FromEnvP("MH_API_HOST", "").(string), "API URL for MailHog UI to connect to, e.g. http://some.host:1234")
 	flag.StringVar(&cfg.UIBindAddr, "ui-bind-addr", envconf.FromEnvP("MH_UI_BIND_ADDR", "0.0.0.0:8025").(string), "HTTP bind interface and port for UI, e.g. 0.0.0.0:8025 or just :8025")
+	flag.StringVar(&cfg.WebPath, "ui-web-path", envconf.FromEnvP("MH_UI_WEB_PATH", "").(string), "WebPath under which the ui is served (without leading or trailing slahes), e.g. /mailhog defaults to ''")
 }

--- a/web/web.go
+++ b/web/web.go
@@ -14,6 +14,7 @@ import (
 )
 
 var APIHost string
+var WebPath string
 
 type Web struct {
 	config *config.Config
@@ -26,11 +27,20 @@ func CreateWeb(cfg *config.Config, pat *pat.Router, asset func(string) ([]byte, 
 		asset:  asset,
 	}
 
-	pat.Path("/images/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/images/{{file}}"))
-	pat.Path("/css/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/css/{{file}}"))
-	pat.Path("/js/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/js/{{file}}"))
-	pat.Path("/fonts/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/fonts/{{file}}"))
-	pat.Path("/").Methods("GET").HandlerFunc(web.Index())
+	WebPath = cfg.WebPath
+
+	//add a leading slash
+	if WebPath != "" && !(WebPath[0] == '/') {
+		WebPath = "/" + WebPath
+	}
+
+	log.Printf("Serving under http://%s%s/", cfg.UIBindAddr, WebPath)
+
+	pat.Path(WebPath + "/images/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/images/{{file}}"))
+	pat.Path(WebPath + "/css/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/css/{{file}}"))
+	pat.Path(WebPath + "/js/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/js/{{file}}"))
+	pat.Path(WebPath + "/fonts/{file:.*}").Methods("GET").HandlerFunc(web.Static("assets/fonts/{{file}}"))
+	pat.Path(WebPath + "/").Methods("GET").HandlerFunc(web.Index())
 
 	return web
 }


### PR DESCRIPTION
I introduced a new Parameter, which allows defining a webpath.
Mailhog is then served under this webpath.