### PR TITLE
Create hyperlinks for URLs in plaintext emails

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -404,6 +404,26 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
 
     return content;
   }
+  
+  $scope.formatMessagePlain = function(message) {
+    var body = $scope.getMessagePlain(message);
+    var escaped = $scope.escapeHtml(body);
+    var formatted = escaped.replace(/(https?:\/\/)([-[\]A-Za-z0-9._~:/?#@!$()*+,;=%]|&amp;|&#39;)+/g, '<a href="$&" target="_blank">$&</a>');
+    return $sce.trustAsHtml(formatted);
+  }
+  
+  $scope.escapeHtml = function(html) {
+    var entityMap = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return html.replace(/[&<>"']/g, function (s) {
+      return entityMap[s];
+    });
+  }
 
   $scope.getMessagePlain = function(message) {
     if (message.Content.Headers && message.Content.Headers["Content-Type"] && message.Content.Headers["Content-Type"][0].match("text/plain")) {
@@ -414,7 +434,7 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
       return $scope.tryDecode(l);
     }
     return message.Content.Body;
-	}
+  }
 
   $scope.findMatchingMIME = function(part, mime) {
     // TODO cache results

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -186,7 +186,7 @@
 
     <div class="tab-content">
       <iframe target-blank="" ng-if="hasHTML(preview)" ng-class="{ active: hasHTML(preview) }" class="tab-pane" id="preview-html" srcdoc="{{preview.previewHTML}}" seamless frameborder="0" style="width: 100%"></iframe>
-      <div class="tab-pane" ng-class="{ active: !hasHTML(preview) }" id="preview-plain">{{ getMessagePlain(preview) }}</div>
+      <div class="tab-pane" ng-class="{ active: !hasHTML(preview) }" id="preview-plain" ng-bind-html="formatMessagePlain(preview)"></div>
       <div class="tab-pane" id="preview-source">{{ getSource(preview) }}</div>
       <div class="tab-pane" id="preview-mime">
         <div ng-repeat="part in preview.MIME.Parts" class="mime-part">


### PR DESCRIPTION
This will change all URLs found in plaintext emails to hyperlinks. The links should open in a new tab, like they currently do with HTML emails.

The regexp to find URLs is fairly dumb, but it seems to do the job - for each occurrence of http:// or https://, it just keeps going until it finds a character that is not valid in a URL (e.g. whitespace).

I didn't commit the updated assets.go, since I'm using Windows which messed with the line-endings and file permissions (which I'm 98% sure doesn't actually matter, but I'm erring on the side of caution). 