### PR TITLE
Add no-referrer referrer policy to prevent leakage of sensitive info

### DIFF
--- a/assets/templates/layout.html
+++ b/assets/templates/layout.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="no-referrer">
 
     <link rel="icon" type="image/png" href="images/hog.png">
 


### PR DESCRIPTION
This prevents Referer headers from being sent when requesting any
external assets, and when clicking on any offsite links, such as the
github link in the top-right corner of the page. This helps to prevent
the leakge of sensitive details, such as private domain names.