### PR TITLE
Make the UI usable on smaller screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -23,6 +23,11 @@
 #search {
   width: 500px;
 }
+@media (max-width: 991px) {
+  #search {
+    width: 420px;
+  }
+}
 
 /* http://stackoverflow.com/questions/18838964/add-bootstrap-glyphicon-to-input-box */
 .left-inner-addon {

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -29,7 +29,7 @@
 
 <div class="messages container-fluid" ng-if="!preview && !searching">
   <div class="msglist-message row" ng-repeat="message in messages" ng-click="selectMessage(message)">
-    <div class="col-md-3">
+    <div class="col-md-3 col-sm-4">
       {{ tryDecodeMime(getDisplayName(message.Content.Headers["From"][0]) || message.From.Mailbox + "@" + message.From.Domain) }}
 
       <div ng-if="message.Content.Headers['To']">
@@ -45,15 +45,18 @@
       </div>
     </div>
 
-    <div class="col-md-5">
+    <div class="col-md-5 col-sm-5">
       <span class="subject unread">{{ tryDecodeMime(message.Content.Headers["Subject"][0]) }}</span>
     </div>
-
-    <div class="col-md-3 text-right">
-      {{ getMoment(date(message.Created)).fromNow() }}
-    </div>
-    <div class="col-md-1 text-right">
-      {{ fileSize(message.Raw.Data.length) }}
+    <div class="col-md-4 col-sm-3">
+      <div class="row">
+        <div class="col-md-9 col-sm-12 text-right">
+          {{ getMoment(date(message.Created)).fromNow() }}
+        </div>
+        <div class="col-md-3 col-sm-12 text-right">
+          {{ fileSize(message.Raw.Data.length) }}
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -89,7 +92,7 @@
 
 <div class="messages container-fluid" ng-if="searching">
   <div class="msglist-message row" ng-repeat="message in searchMessages" ng-click="selectMessage(message)">
-    <div class="col-md-3">
+    <div class="col-md-3 col-sm-4">
       {{ tryDecodeMime(getDisplayName(message.Content.Headers["From"][0]) || message.From.Mailbox + "@" + message.From.Domain) }}
 
       <div ng-if="message.Content.Headers['To']">
@@ -105,11 +108,11 @@
       </div>
     </div>
 
-    <div class="col-md-3">
+    <div class="col-md-3 col-sm-5">
       <span class="subject unread">{{ tryDecodeMime(message.Content.Headers["Subject"][0]) }}</span>
     </div>
 
-    <div class="col-md-3 col-md-offset-3 text-right">
+    <div class="col-md-3 col-md-offset-3 col-sm-3 text-right">
       {{ getMoment(date(message.Created)).fromNow() }}
     </div>
   </div>

--- a/assets/templates/layout.html
+++ b/assets/templates/layout.html
@@ -16,7 +16,7 @@
   <body ng-controller="MailCtrl" ng-click="keepopen=false">
     <nav class="navbar navbar-default navbar-static-top" role="navigation">
       <div class="container-fluid">
-        <div class="col-md-2">
+        <div class="col-md-2 col-sm-3">
           <div class="navbar-header">
             <a class="navbar-brand" href="#">
               <img src="images/hog.png" height="20" alt="MailHog"> MailHog
@@ -24,7 +24,7 @@
           </div>
         </div>
 
-        <div class="col-md-10">
+        <div class="col-md-10 col-sm-9">
           <form class="navbar-form navbar-left" role="search">
             <div class="form-group left-inner-addon">
               <i class="glyphicon glyphicon-search"></i>
@@ -58,7 +58,7 @@
 
     <div class="container-fluid">
       <div class="row">
-        <div class="col-md-2">
+        <div class="col-md-2 col-sm-3">
           <ul class="nav nav-pills nav-stacked">
             <li>
               <a href="#" title="Event stream connected" ng-click="toggleStream()">
@@ -130,7 +130,7 @@
           </div>
         </div>
 
-        <div class="col-md-10 content">
+        <div class="col-md-10 col-sm-9 content">
           [: .Content :]
         </div>
       </div>


### PR DESCRIPTION
Previously, the UI would break when viewed in a screen/window less than 992px wide - the main problem with this for me was that I couldn't let the window snap to fill half of a 1920x1080 screen. With this PR, It now works for windows 768px+ wide.

Before:
![ui_old](https://cloud.githubusercontent.com/assets/9611672/16632675/28b60074-43bd-11e6-8c5a-10ddc265dbdc.PNG)

After:
![ui_new](https://cloud.githubusercontent.com/assets/9611672/16632678/2e00ccee-43bd-11e6-8452-f9c30db5249e.PNG)


