### PR TITLE
Show desktop notifications for new emails

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -98,6 +98,9 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
 
   $(function() {
     $scope.openStream();
+    if(typeof(Notification) !== "undefined") {
+      Notification.requestPermission();
+    }
   });
 
   $scope.getMoment = function(a) {
@@ -132,9 +135,13 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
         if ($scope.countMessages < $scope.itemsPerPage) {
           $scope.countMessages++;
         }
-        $scope.messages.unshift(JSON.parse(e.data));
+        var message = JSON.parse(e.data);
+        $scope.messages.unshift(message);
         while($scope.messages.length > $scope.itemsPerPage) {
           $scope.messages.pop();
+        }
+        if(typeof(Notification) !== "undefined") {
+          $scope.createNotification(message);
         }
       });
     }, false);
@@ -157,6 +164,21 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
     $scope.hasEventSource = false;
   }
 
+  $scope.createNotification = function(message) {
+    var title = "Mail from " + $scope.getSender(message);
+    var options = {
+      body: $scope.tryDecodeMime(message.Content.Headers["Subject"][0]),
+      tag: "MailHog",
+      icon: "images/hog.png"
+    };
+    var notification = new Notification(title, options);
+    notification.addEventListener('click', function(e) {
+      $scope.selectMessage(message);
+      window.focus();
+      notification.close();
+    });
+  }
+
   $scope.tryDecodeMime = function(str) {
     return unescapeFromMime(str)
   }
@@ -164,6 +186,11 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
   $scope.resizePreview = function() {
     $('.tab-content').height($(window).innerHeight() - $('.tab-content').offset().top);
     $('.tab-content .tab-pane').height($(window).innerHeight() - $('.tab-content').offset().top);
+  }
+
+  $scope.getSender = function(message) {
+    return $scope.tryDecodeMime($scope.getDisplayName(message.Content.Headers["From"][0]) ||
+                                message.From.Mailbox + "@" + message.From.Domain);
   }
 
   $scope.getDisplayName = function(value) {

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -90,7 +90,7 @@
 <div class="messages container-fluid" ng-if="searching">
   <div class="msglist-message row" ng-repeat="message in searchMessages" ng-click="selectMessage(message)">
     <div class="col-md-3">
-      {{ tryDecodeMime(getDisplayName(message.Content.Headers["From"][0]) || message.From.Mailbox + "@" + message.From.Domain) }}
+      {{ getSender(message) }}
 
       <div ng-if="message.Content.Headers['To']">
         <div ng-repeat="to in message.Content.Headers['To']" style="color: #777">

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -30,7 +30,7 @@
 <div class="messages container-fluid" ng-if="!preview && !searching">
   <div class="msglist-message row" ng-repeat="message in messages" ng-click="selectMessage(message)">
     <div class="col-md-3">
-      {{ tryDecodeMime(getDisplayName(message.Content.Headers["From"][0]) || message.From.Mailbox + "@" + message.From.Domain) }}
+      {{ getSender(message) }}
 
       <div ng-if="message.Content.Headers['To']">
         <div ng-repeat="to in message.Content.Headers['To']" style="color: #777">


### PR DESCRIPTION
This PR will make the UI display a desktop notification with the sender address and subject line whenever a new email is received. The user is asked for permission to create desktop notifications on first page load. All notifications are given the same tag, which means only one notification will be shown at any time. Clicking the notification will select the message and focus the window.

Notifications look like this in chrome:
![notification_chrome](https://cloud.githubusercontent.com/assets/9611672/16633300/93b4364a-43c0-11e6-9ce4-a7a99c59c531.PNG)

And this in Firefox:
![notification_ff](https://cloud.githubusercontent.com/assets/9611672/16633305/97bbace6-43c0-11e6-9665-0e71396a6298.PNG)

