### PR TITLE
Allow re-use of CID's

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -367,13 +367,10 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
             }
           }
         }
-        console.log(data.$cidMap)
-        // TODO
-        // - scan HTML parts for elements containing CID URI and replace
 
         h = $scope.getMessageHTML(data)
         for(c in data.$cidMap) {
-          h = h.replace("cid:" + c, data.$cidMap[c])
+          h = h.split("cid:" + c).join(data.$cidMap[c]);
         }
 	      data.previewHTML = $sce.trustAsHtml(h);
   		  $scope.preview = data;


### PR DESCRIPTION
I was creating a daily digest newsletter for a intranet, in this newsletter we also add avatars of users, these avatars are added with CID's.

I noticed that Mailhog does not support reusing re-using of CID's, it only replaces the first instance. This is because of a bug in the javascript, it uses the JS String.replace() method which only replaces the first instance by default. I replaced it by a version that uses String.split() and String.join().

I also removed the TODO as it seems to be implemented already.