### PR TITLE
replace all occurrences of the same CID reference

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -373,7 +373,9 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
 
         h = $scope.getMessageHTML(data)
         for(c in data.$cidMap) {
-          h = h.replace("cid:" + c, data.$cidMap[c])
+	  str = "cid:" + c;
+	  pat = str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+          h = h.replace(new RegExp(pat, 'g'), data.$cidMap[c])
         }
 	      data.previewHTML = $sce.trustAsHtml(h);
   		  $scope.preview = data;


### PR DESCRIPTION
This fixes the incorrect behaviour of only replacing the _first_ instance of a CID reference by using a regular expression with a global flag.

Example: referencing the same inline-attachment in multiple places within the same email (often used for responsive HTML emails)