### PR TITLE
Remove newlines represented by LF as well as CRLF

### DIFF
--- a/assets/js/controllers.js
+++ b/assets/js/controllers.js
@@ -422,7 +422,7 @@ mailhogApp.controller('MailCtrl', function ($scope, $http, $sce, $timeout) {
     if(contentTransferEncoding) {
       switch (contentTransferEncoding.toLowerCase()) {
         case 'quoted-printable':
-          content = content.replace(/=[\r\n]+/gm,"");
+          content = content.replace(/=(\r\n|\n)+/gm,"");
           content = unescapeFromQuotedPrintableWithoutRFC2047(content, charset);
           break;
         case 'base64':


### PR DESCRIPTION
The quoted-printable standard seems to require CRLF line breaks, but many clients support LF too. This patch allows for supporting the LF case in addition to CRLF.

This should fix #35.