### PR TITLE
Fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ bindata-deps:
 fmt:
 	go fmt ./...
 
-.PNONY: all ui bindata bindata-deps fmt
+.PHONY: all ui bindata bindata-deps fmt


### PR DESCRIPTION
Replace `.PNONY` with `.PHONY`